### PR TITLE
index: add "Portugal" in meta keywords and title

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,10 +2,11 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>Quarenta Anos de Abstenção</title>
+  <title>Quarenta Anos de Abstenção em Portugal</title>
   <link rel="shortcut icon" href="favicons/favicon.ico">
   <meta property="og:image" content="images/40-Anos-de-Abstencao.png" />
   <meta property="og:description" content="Quarenta anos de Abstenção, uma visualização dos resultados das eleições legislativas em Portugal, entre 1975 e 2011." />
+  <meta name="keywords" content="abstenção,Portugal,eleições">
   <!-- inject:css -->
   <link rel="stylesheet" href="css/app.min.css">
   <link rel="stylesheet" href="foundation-icons/foundation-icons.css">

--- a/index.html
+++ b/index.html
@@ -1,15 +1,15 @@
 <!DOCTYPE html>
-<html lang="en">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
 <head>
-  <meta charset="UTF-8">
+  <meta charset="UTF-8" />
   <title>Quarenta Anos de Abstenção em Portugal</title>
-  <link rel="shortcut icon" href="favicons/favicon.ico">
+  <link rel="shortcut icon" href="favicons/favicon.ico" />
   <meta property="og:image" content="images/40-Anos-de-Abstencao.png" />
   <meta property="og:description" content="Quarenta anos de Abstenção, uma visualização dos resultados das eleições legislativas em Portugal, entre 1975 e 2011." />
-  <meta name="keywords" content="abstenção,Portugal,eleições">
+  <meta name="keywords" content="abstenção,Portugal,eleições" />
   <!-- inject:css -->
-  <link rel="stylesheet" href="css/app.min.css">
-  <link rel="stylesheet" href="foundation-icons/foundation-icons.css">
+  <link rel="stylesheet" href="css/app.min.css" />
+  <link rel="stylesheet" href="foundation-icons/foundation-icons.css" />
   <!-- endinject -->
   <!-- inject:head:js -->
   <script src="js/modernizr.js"></script>
@@ -21,25 +21,23 @@
   </header>
   <section id="intro">
     <div class="row text-center">
-          <p>Os resultados eleitorais que encontramos nos jornais, televisões e outros meios são quase sempre apresentados com a abstenção como um dado à parte, com as percentagens dos votos relativas ao número de pessoas que votaram. E se tentássemos ver essas percentagens face à população do país, incluindo as pessoas que não votaram? Qual é a percentagem da população responsável por eleger os sucessivos governos?</p>
-          <p>Nesta experiência de visualização das legislativas, mostramos do lado esquerdo a divisão convencional dos votos, relativa ao número de votos expressos; do lado direito, encontramos as proporções face à população total. Ao passar o rato por cada coluna, é possível comparar as percentagens segundo ambos os métodos de contagem.</p>
+      <p>Os resultados eleitorais que encontramos nos jornais, televisões e outros meios são quase sempre apresentados com a abstenção como um dado à parte, com as percentagens dos votos relativas ao número de pessoas que votaram. E se tentássemos ver essas percentagens face à população do país, incluindo as pessoas que não votaram? Qual é a percentagem da população responsável por eleger os sucessivos governos?</p>
+      <p>Nesta experiência de visualização das legislativas, mostramos do lado esquerdo a divisão convencional dos votos, relativa ao número de votos expressos; do lado direito, encontramos as proporções face à população total. Ao passar o rato por cada coluna, é possível comparar as percentagens segundo ambos os métodos de contagem.</p>
     </div>
     <div class="row">
-          <div class="small-5 columns text-center"><h4>Percentagem relativa</h4></div>
-          <div class="small-5 columns text-center"><h4>Percentagem real</h4></div>
+      <div class="small-5 columns text-center"><h4>Percentagem relativa</h4></div>
+      <div class="small-5 columns text-center"><h4>Percentagem real</h4></div>
     </div>
   </section>
-  <div id="container">
-  </div>
+  <div id="container"></div>
   <footer id="footer" class="row text-center">
-    <p><strong>Quarenta Anos de Abstenção</strong> foi começado no <a href="http://datewithdata.pt" target="_blank"><img src="/images/datewithdata.svg" onerror="this.src='/images/datewithdata.png'" alt="Date with Data"></a> de setembro 2015, por:</p>
+    <p><strong>Quarenta Anos de Abstenção</strong> foi começado no <a href="http://datewithdata.pt" target="_blank"><img src="/images/datewithdata.svg" onerror="this.src='/images/datewithdata.png'" alt="Date with Data" /></a> de setembro 2015, por:</p>
     <ul class="credits">
-      <li><a href="http://tiagovieira.pt" target="_blank">Tiago Vieira</a> &amp; <a href="http://twitter.com/aiscarvalho" target="_blank">Ana Isabel Carvalho</a> &ndash; development</li>
-      <li><a href="http://twitter.com/rlaf" target="_blank">Ricardo Lafuente</a> &amp; <a href="http://www.ces.uc.pt/investigadores/index.php?action=bio&id_investigador=592" target="_blank">Chiara Carrozza</a> &ndash; recolha e tratamento de dados</li>
+      <li><a href="http://tiagovieira.pt" target="_blank">Tiago Vieira</a> &amp; <a href="http://twitter.com/aiscarvalho" target="_blank">Ana Isabel Carvalho</a> – development</li>
+      <li><a href="http://twitter.com/rlaf" target="_blank">Ricardo Lafuente</a> &amp; <a href="http://www.ces.uc.pt/investigadores/index.php?action=bio&amp;id_investigador=592" target="_blank">Chiara Carrozza</a> – recolha e tratamento de dados</li>
     </ul>
-    <p>Um projeto criado com datasets da <a href="http://centraldedados.pt" target="_blank"><img src="images/centraldedados.png" alt="Central de Dados"> Central de Dados</a> e apoio do <a href="http://transparenciahackday.org" target="_blank"><img src="images/thd-pixel.png" alt="Transparência Hackday"></a> e da <a href="http://okfn.org/network/portugal" target="_blank"><img src="images/okfn-pt.png" alt="Open Knowledge Portugal"></a>.</p>
+    <p>Um projeto criado com datasets da <a href="http://centraldedados.pt" target="_blank"><img src="images/centraldedados.png" alt="Central de Dados" /> Central de Dados</a> e apoio do <a href="http://transparenciahackday.org" target="_blank"><img src="images/thd-pixel.png" alt="Transparência Hackday" /></a> e da <a href="http://okfn.org/network/portugal" target="_blank"><img src="images/okfn-pt.png" alt="Open Knowledge Portugal" /></a>.</p>
     <p>Títulos compostos com <a href="http://ndiscovered.com/cinzel/" target="_blank">Cinzel</a>, uma fonte livre desenhada por <a href="http://ndiscovered.com/about/" target="_blank">Natanael Gama</a>.</p>
-    </div>
   </footer>
   <!-- inject:js -->
   <script src="js/app.min.js"></script>


### PR DESCRIPTION
Web searches for "abstenção portugal" in various search engines didn't list this page among the first several results. Hopefully adding a meta keyword tag, and editing the title tag, will help alleviate this.

(Note: the second commit is just cleanup and does not affect the output. For a cleaner diff, see c217ada.)